### PR TITLE
Fix flavored build with subproject and configure kotlin for sample subproject 

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,5 +19,6 @@ gradle-android = ["gradle-android-sdk-common", "gradle-android-build", "gradle-a
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 publisher = { id = "io.deepmedia.tools.deployer", version.ref = "publisher" }
 android-library = { id = "com.android.library", version.ref = "agp" }

--- a/grease/src/main/kotlin/io/deepmedia/tools/grease/configurations.kt
+++ b/grease/src/main/kotlin/io/deepmedia/tools/grease/configurations.kt
@@ -118,7 +118,11 @@ internal fun Project.createProductFlavorConfigurations(
             val buildTypedSubFlavor = nameOf(subFlavor, variant.buildType.orEmpty())
             log.d { "Creating buildTyped sub product flavor configuration ${buildTypedSubFlavor.greasify()}..." }
             val config = createGrease(buildTypedSubFlavor, isTransitive)
+            config.attributes {
+                attribute(BuildTypeAttr.ATTRIBUTE, objects.named(BuildTypeAttr::class, variant.buildType.orEmpty()))
+            }
             config.extendsFromSafely(grease(isTransitive), log)
+            config.extendsFromSafely(greaseOf(variant.buildType.orEmpty(), isTransitive), log)
             config.extendsFromSafely(greaseOf(subFlavor, isTransitive), log)
             config.extendsFromSafely(flavorConfiguration, log)
         }
@@ -153,6 +157,9 @@ internal fun Project.createVariantConfigurations(
 ) = androidComponent.onVariants { variant ->
     log.d { "Creating variant configuration ${variant.name.greasify()}..." }
     val config = createGrease(variant.name, isTransitive)
+    config.attributes {
+        attribute(BuildTypeAttr.ATTRIBUTE, objects.named(BuildTypeAttr::class, variant.buildType.orEmpty()))
+    }
     config.extendsFromSafely(grease(isTransitive), log)
     config.extendsFromSafely(greaseOf(variant.buildType.orEmpty(), isTransitive), log)
     variant.flavorName?.let { flavor ->

--- a/tests/sample-dependency-pure/build.gradle.kts
+++ b/tests/sample-dependency-pure/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.android.library)
+    alias(libs.plugins.kotlin.android)
 }
 
 android {
@@ -7,6 +8,10 @@ android {
     compileSdk = 34
     defaultConfig {
         minSdk = 21
+    }
+
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
 }
 

--- a/tests/sample-library/build.gradle.kts
+++ b/tests/sample-library/build.gradle.kts
@@ -68,7 +68,5 @@ dependencies {
     // Manifest changes, layout resources
     grease("com.otaliastudios:cameraview:2.7.2")
 
-    // Doesn't work. TODO: we need to configure grease configurations so that in case of multiple matching
-    // variants, they prefer one where com.android.build.api.attributes.BuildTypeAttr is set to release
-    // grease(project(":sample-dependency-pure"))
+    grease(project(":sample-dependency-pure"))
 }


### PR DESCRIPTION
Fix for #4 