### PR TITLE
refactor: Include java resources to final aar

### DIFF
--- a/grease/build.gradle.kts
+++ b/grease/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "io.deepmedia.tools"
-version = "0.3.4"
+version = "0.3.5"
 
 testing {
     suites {

--- a/grease/src/main/kotlin/io/deepmedia/tools/grease/GreasePlugin.kt
+++ b/grease/src/main/kotlin/io/deepmedia/tools/grease/GreasePlugin.kt
@@ -440,7 +440,8 @@ open class GreasePlugin : Plugin<Project> {
 
             fun injectClasses(inputJar: File) {
                 log.d { "Processing inputJar=$inputJar outputDir=${jarExtractWorkdir}..." }
-                val inputFiles = target.zipTree(inputJar).matching { include("**/*.class", "**/*.kotlin_module") }
+                //keep java resources from jar
+                val inputFiles = target.zipTree(inputJar)
                 target.copy {
                     from(inputFiles)
                     into(jarExtractWorkdir)

--- a/tests/build.gradle.kts
+++ b/tests/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.kotlin.android) apply false
+}

--- a/tests/sample-dependency-library/build.gradle.kts
+++ b/tests/sample-dependency-library/build.gradle.kts
@@ -10,8 +10,13 @@ android {
         minSdk = 21
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 }
 

--- a/tests/sample-dependency-pure/build.gradle.kts
+++ b/tests/sample-dependency-pure/build.gradle.kts
@@ -10,8 +10,13 @@ android {
         minSdk = 21
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "17"
     }
 }
 

--- a/tests/sample-library/build.gradle.kts
+++ b/tests/sample-library/build.gradle.kts
@@ -54,6 +54,15 @@ android {
             path = file("src/main/CMakeLists.txt")
         }
     }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
 }
 
 dependencies {

--- a/tests/sample-library/src/main/java/io/deepmedia/tools/grease/sample/library/spi/CommandHandler.kt
+++ b/tests/sample-library/src/main/java/io/deepmedia/tools/grease/sample/library/spi/CommandHandler.kt
@@ -1,0 +1,5 @@
+package io.deepmedia.tools.grease.sample.library.spi
+
+interface CommandHandler {
+    fun handle()
+}

--- a/tests/sample-library/src/main/java/io/deepmedia/tools/grease/sample/library/spi/SimpleHandler.kt
+++ b/tests/sample-library/src/main/java/io/deepmedia/tools/grease/sample/library/spi/SimpleHandler.kt
@@ -1,0 +1,7 @@
+package io.deepmedia.tools.grease.sample.library.spi
+
+class SimpleHandler : CommandHandler {
+    override fun handle() {
+        println("SPI simple handler")
+    }
+}

--- a/tests/sample-library/src/main/resources/META-INF/services/io.deepmedia.tools.grease.sample.library.spi.CommandHandler
+++ b/tests/sample-library/src/main/resources/META-INF/services/io.deepmedia.tools.grease.sample.library.spi.CommandHandler
@@ -1,0 +1,1 @@
+io.deepmedia.tools.grease.sample.library.spi.SimpleHandler


### PR DESCRIPTION
Increase version. Configure kotlin in tests

Problem:

First of all, thanks for your plugin. I tried using the current version 0.3.4, and I found a bug. I have some logic related to Java [SPI](https://docs.oracle.com/javase/tutorial/ext/basics/spi). I need to keep the META-INF/services/ directory in the jar file. But now, this directory is being excluded by the plugin. Or for [this](https://github.com/locationtech/proj4j) dependency I must keep all java resources.